### PR TITLE
Fixing radnom generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,33 @@
-bin/*
-.project
-.settings
-.classpath
+# Created by https://www.gitignore.io
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws

--- a/src/org/datafactory/DataFactory.java
+++ b/src/org/datafactory/DataFactory.java
@@ -14,7 +14,10 @@ import org.datafactory.values.impl.RBAddressDataValues;
 import org.datafactory.values.impl.RBContentDataValues;
 
 public class DataFactory {
-
+	/*
+		Default constructor of Random class will use System.nanoTime() as seed generator so
+		every other usage will generate different output
+	 */
 	private static Random random = new Random();
 
 	private Locale locale;

--- a/src/org/datafactory/DataFactory.java
+++ b/src/org/datafactory/DataFactory.java
@@ -15,7 +15,7 @@ import org.datafactory.values.impl.RBContentDataValues;
 
 public class DataFactory {
 
-	private static Random random = new Random(93285);
+	private static Random random = new Random();
 
 	private Locale locale;
 


### PR DESCRIPTION
DataFactory now generates same output each time. Default constructor should be used (which uses System.nanoTime()), since it will result in different output each time.
